### PR TITLE
English - Remove duplicate keys from events.json.

### DIFF
--- a/en/events.json
+++ b/en/events.json
@@ -1,7 +1,4 @@
 {
-  "page-title": "Upcoming Events ({{platform}}) - Eric's GoW Tools",
-  "page-desc": "List of future events in Gems of War, updated daily.",
-
   "head-name": "Name",
   "head-start-date": "Start Date",
   "head-end-date": "End Date",


### PR DESCRIPTION
These keys already exist in `./pages.json`.